### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -150,6 +150,8 @@ jobs:
     if: ${{ needs.release.outputs.rc == 'false' }}
     runs-on: ubuntu-latest
     needs: release
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Potential fix for [https://github.com/HyperCogWizard/aichat/security/code-scanning/2](https://github.com/HyperCogWizard/aichat/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the `publish-crate` job. Since the job primarily involves publishing a crate to `crates.io`, it does not require write access to the repository contents. The minimal required permission is `contents: read`. This change ensures that the job has the least privileges necessary to perform its task.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
